### PR TITLE
Fix external WiLoR integration bug caused by missing img_feat

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ conda activate h4wpp
 * Move to `common/nets` and clone [[WiLoR](https://github.com/rolpotamias/WiLoR)] and download its pretrained weights following the instruction.
 * Move to `common/nets` and download [[mmpose](https://drive.google.com/file/d/1Rxjb9l5m49lhoxfW0ohubl19vVRx9Q_n/view?usp=sharing)]. Place [[DWPose](https://drive.google.com/file/d/1PHKN3p873dgCSh_YRsYqTZVj-kIbclRS/view?usp=sharing)] at `common/nets/mmpose/dw-ll_ucoco.pth`.
 
+* External WiLoR patch
+
+    Hand4Whole++ was tested with WiLoR commit `50847f9`.
+
+    After cloning WiLoR, please apply the provided patch before running the code:
+
+    ```bash
+    cd common/nets/WiLoR
+    git checkout 50847f9
+    cd ../../..
+    bash patches/apply_wilor_patch.sh
 
 ## Demo
 * Download the pre-trained Hand4Whole++ from [here](https://drive.google.com/drive/folders/1sDWjihPLcjJNTzQbGUedJ3zaK0AyalBt?usp=sharing).

--- a/patches/apply_wilor_patch.sh
+++ b/patches/apply_wilor_patch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+WILOR_DIR="${1:-common/nets/WiLoR}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PATCH_FILE="$SCRIPT_DIR/hand4wholepp_img_feat.patch"
+
+if [ ! -d "$WILOR_DIR/.git" ]; then
+  echo "Error: '$WILOR_DIR' is not a git repository."
+  echo "Usage: bash patches/apply_wilor_patch.sh [path/to/WiLoR]"
+  echo "Default: common/nets/WiLoR"
+  exit 1
+fi
+
+git -C "$WILOR_DIR" apply "$PATCH_FILE"
+echo "Applied WiLoR patch successfully to $WILOR_DIR"

--- a/patches/hand4wholepp_img_feat.patch
+++ b/patches/hand4wholepp_img_feat.patch
@@ -1,0 +1,21 @@
+diff --git a/wilor/models/wilor.py b/wilor/models/wilor.py
+index d1415d4..79cc2dc 100644
+--- a/wilor/models/wilor.py
++++ b/wilor/models/wilor.py
+@@ -109,7 +109,6 @@ class WiLoR(pl.LightningModule):
+         # Compute conditioning features using the backbone
+         # if using ViT backbone, we need to use a different aspect ratio
+         temp_mano_params, pred_cam, pred_mano_feats, vit_out = self.backbone(x[:,:,:,32:-32]) # B, 1280, 16, 12  
+-
+     
+         # Compute camera translation
+         device = temp_mano_params['hand_pose'].device
+@@ -156,6 +155,8 @@ class WiLoR(pl.LightningModule):
+                                                    translation=pred_cam_t,
+                                                    focal_length=focal_length / self.cfg.MODEL.IMAGE_SIZE)
+         output['pred_keypoints_2d'] = pred_keypoints_2d.reshape(batch_size, -1, 2)
++
++        output['img_feat'] = vit_out
+         
+         return output
+ 


### PR DESCRIPTION
## Summary
This PR adds a small patch and helper script for the external WiLoR dependency used by Hand4Whole++.

## Problem
Hand4Whole++ expects `img_feat` in the WiLoR forward output during integration with the external WiLoR checkout.

Without this patch, the following runtime error occurs:

```python
img_feat = out['img_feat'].float()
KeyError: 'img_feat'
```

## Cause

Hand4Whole++ expects img_feat in the WiLoR forward output, but the tested WiLoR commit (50847f9) does not return it by default.

## Fix
- Added a patch file to expose img_feat as output['img_feat'] = vit_out

- Added a helper script to apply the patch

- Documented the tested WiLoR commit and patch workflow in the README